### PR TITLE
Removed connection string from appsettings.

### DIFF
--- a/backendTuneAPI/Controllers/UsersController.cs
+++ b/backendTuneAPI/Controllers/UsersController.cs
@@ -18,7 +18,7 @@ namespace backendTuneAPI.Controllers
         [HttpGet]
         public JsonResult Get()
         {
-            MongoClient dbClient = new MongoClient(_configuration.GetConnectionString("BackendTuneCon"));
+            MongoClient dbClient = new MongoClient(_configuration["MongoDBAtlas:ConnectionString"]);
 
             var dbList = dbClient.GetDatabase("testdb").GetCollection<Users>("users").AsQueryable();
 

--- a/backendTuneAPI/appsettings.json
+++ b/backendTuneAPI/appsettings.json
@@ -1,7 +1,4 @@
 {
-    "ConnectionStrings": {
-        "BackendTuneCon": "mongodb+srv://erikajasmine06:s0uR_graPEs@backend.0wrzf.mongodb.net/?retryWrites=true&w=majority&appName=Backend"
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/backendTuneAPI/backendTuneAPI.csproj
+++ b/backendTuneAPI/backendTuneAPI.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>ce367f95-58c1-4a16-b146-e1f6a0015c05</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To add the Connection String back locally:
1. Right click the project and click Manage User Secrets
![image](https://github.com/user-attachments/assets/3d779ba7-b72a-44fc-b29a-72745b9bdb35)
2. Paste the following and save into secrets.json: (Refer to discord for connection string)
`{
  "MongoDBAtlas:ConnectionString": "INSERT CONNECTION STRING HERE"
}`