### PR TITLE
Added JWT Authentication for necessary API endpoints

### DIFF
--- a/backendTuneAPI/Controllers/JwtAuthController.cs
+++ b/backendTuneAPI/Controllers/JwtAuthController.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using MoodzApi.Models;
+using MoodzApi.Services;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace MoodzApi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class JwtAuthController : ControllerBase
+    {
+        private readonly UsersService _usersService;
+        public JwtAuthController(UsersService usersService)
+        {
+            _usersService = usersService;
+        }
+
+        [HttpPost("token")]
+        public IActionResult GenerateJWTToken(string userId)
+        {
+            var tokenString = _usersService.GenerateToken(userId);
+
+            return Ok(new { Token = tokenString });
+        }
+    }
+}

--- a/backendTuneAPI/Controllers/SpotifyController.cs
+++ b/backendTuneAPI/Controllers/SpotifyController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using MoodzApi.Models;
 using MoodzApi.Services;
 
@@ -46,7 +47,9 @@ public class SpotifyController : ControllerBase
     // }
 
     //get api endpoint to request most recently played tracks
+ 
     [HttpGet("recently-played/{userId}")]
+    [Authorize]
     public async Task<IActionResult> GetRecentlyPlayed(string userId)
     {
         try

--- a/backendTuneAPI/Controllers/UsersController.cs
+++ b/backendTuneAPI/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using MoodzApi.Services;
 using MoodzApi.Mappers;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authorization;
 
 namespace MoodzApi.Controllers;
 

--- a/backendTuneAPI/Models/JwtSettings.cs
+++ b/backendTuneAPI/Models/JwtSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace MoodzApi.Models;
+
+public class JwtSettings
+{
+    public string Issuer { get; set; } = null!;
+    public string Audience { get; set; } = null!;
+    public string SecretKey { get; set; } = null!;
+    public int ExpiryMinutes { get; set; }
+}

--- a/backendTuneAPI/Models/UserState.cs
+++ b/backendTuneAPI/Models/UserState.cs
@@ -5,4 +5,5 @@ public class UserState
     public string Name { get; set; } = null!;
     public string ProfilePicUrl { get; set; } = null!;
     public Entry[] Entries { get; set; } = null!;
+    public string JwtToken { get; set; } = null!;
 }

--- a/backendTuneAPI/MoodzApi.csproj
+++ b/backendTuneAPI/MoodzApi.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
     <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />

--- a/backendTuneAPI/Services/SpotifyService.cs
+++ b/backendTuneAPI/Services/SpotifyService.cs
@@ -216,6 +216,10 @@ public class SpotifyService
             // Condense user information down to just what we want to expose the frontend to
             UserState userState = _userMapper.UserToUserState(user);
 
+            var jwtToken = _usersService.GenerateToken(user.Id);
+
+            userState.JwtToken = jwtToken;
+
             return userState;
         }
         else


### PR DESCRIPTION
Updated secrets.json:
{
    "MongoDBAtlas": {
        "ConnectionString": "CHECK DISCORD",
        "DatabaseName": "CHECK DISCORD",
        "UsersCollectionName": "CHECK DISCORD"
    },
    "SpotifyAuth": {
        "ClientId": "CHECK DISCORD",
        "ClientSecret": "CHECK DISCORD"
    },
    "JwtSettings": {
        "Issuer": "CHECK DISCORD",
        "Audience": "CHECK DISCORD",
        "SecretKey": "CHECK DISCORD",
        "ExpiryMinutes": CHECK DISCORD
    }
}

Added JSON Web Token authentication middleware grabbing fields from secrets.json
![image](https://github.com/user-attachments/assets/e0b2c259-e99c-4eaa-8c32-51a237d04afb)

Added JwtSettings.cs model for necessary fields
![image](https://github.com/user-attachments/assets/48d9a540-d2ef-41f5-9b3e-ed7636097486)

Added JWT generation method in UsersService.cs
![image](https://github.com/user-attachments/assets/0fe53014-8af6-49f1-9500-9af26105c8f0)

Added a JwtAuthController.cs injected with usersService.cs to test generating a token given a user ID.
![image](https://github.com/user-attachments/assets/5cad4880-3e57-4cc4-9486-067f4d45d267)

Modified SpotifyUserLogin in SpotifyService.cs to generate a JWT upon user creation and added it to the userState class. Also added a JwtToken field in UserState.cs. Could probably refactor the code to better implement the token into the userMapper.
![image](https://github.com/user-attachments/assets/11e023dc-7ab3-4a37-9ef5-03b4c178bfbf)

Required recently-played GET endpoint to be authorized with a JWT
![image](https://github.com/user-attachments/assets/f236e261-0bf9-4ed0-b307-20b3dcafaded)

