### PR TITLE
Refactor all endpoints to extract userId from jwt token instead of passing userId as param

### DIFF
--- a/backendTuneAPI/Controllers/SpotifyController.cs
+++ b/backendTuneAPI/Controllers/SpotifyController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using MoodzApi.Models;
 using MoodzApi.Services;
 
 namespace MoodzApi.Controllers;
@@ -10,8 +9,12 @@ namespace MoodzApi.Controllers;
 public class SpotifyController : ControllerBase
 {
     private readonly SpotifyService _spotifyService;
-    public SpotifyController(SpotifyService spotifyService) =>
+    private readonly IUserContext _userContext;
+    public SpotifyController(SpotifyService spotifyService, IUserContext userContext)
+    {
         _spotifyService = spotifyService;
+        _userContext = userContext;
+    }
 
     [HttpGet("search")]
     [Authorize]
@@ -27,10 +30,12 @@ public class SpotifyController : ControllerBase
         }
     }
 
-    [HttpGet("search/v2/{userId}")]
+    [HttpGet("search/v2")]
     [Authorize]
-    public async Task<IActionResult> SearchSpotifyTracksWithUserAccessToken([FromQuery] string query, string userId)
+    public async Task<IActionResult> SearchSpotifyTracksWithUserAccessToken([FromQuery] string query)
     {
+        var userId = _userContext.UserId;
+
         if (string.IsNullOrWhiteSpace(query) || query.Length > 256) return BadRequest("Query must be between 1 and 256 characters.");
 
         try
@@ -44,10 +49,12 @@ public class SpotifyController : ControllerBase
         }
     }
 
-    [HttpGet("track/{trackId}/{userId}")]
+    [HttpGet("track/{trackId}")]
     [Authorize]
-    public async Task<IActionResult> GetTrack(string trackId, string userId)
+    public async Task<IActionResult> GetTrack(string trackId)
     {
+        var userId = _userContext.UserId;
+
         try
         {
             var track = await _spotifyService.GetTrack(trackId, userId);
@@ -81,10 +88,12 @@ public class SpotifyController : ControllerBase
 
     //get api endpoint to request most recently played tracks
 
-    [HttpGet("recently-played/{userId}")]
+    [HttpGet("recently-played")]
     [Authorize]
-    public async Task<IActionResult> GetRecentlyPlayed(string userId)
+    public async Task<IActionResult> GetRecentlyPlayed()
     {
+        var userId = _userContext.UserId;
+
         try
         {
             // Call the service to get the most recent track

--- a/backendTuneAPI/Services/IUserContext.cs
+++ b/backendTuneAPI/Services/IUserContext.cs
@@ -1,0 +1,5 @@
+﻿namespace MoodzApi.Services;
+public interface IUserContext
+{
+    string UserId { get; }
+}

--- a/backendTuneAPI/Services/UserContext.cs
+++ b/backendTuneAPI/Services/UserContext.cs
@@ -1,0 +1,21 @@
+﻿using System.Security.Claims;
+
+namespace MoodzApi.Services;
+public class UserContext : IUserContext
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public UserContext(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public string UserId
+    {
+        get
+        {
+            var user = _httpContextAccessor.HttpContext!.User;
+            return user!.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        }
+    }
+}

--- a/backendTuneAPI/Startup.cs
+++ b/backendTuneAPI/Startup.cs
@@ -78,6 +78,11 @@ namespace MoodzApi
             services.AddSingleton<SpotifyService>();    //Spotify service keeps track of when we need to update auth token
             services.AddSingleton<JwtTokenService>();
 
+            // So that UserContext has access to HttpContextAccessor. HttpContextAccessor allows us to read request information like the jwtToken attached to the request
+            services.AddHttpContextAccessor();
+            // AddScoped means a new instance of this UserContext will be created for every HTTP request. TLDR: Lifespan of UserContext instance is tied to HTTP Request lifespan
+            services.AddScoped<IUserContext, UserContext>();    // Service for reading userId from jwtToken. Can include other things later like isMobile, isTablet, etc.
+
 
             //JSON Serializer
             services.AddControllersWithViews().AddNewtonsoftJson(options =>


### PR DESCRIPTION
This change is vital for user security. This means that only the owner of the jwt token associated with that account is able to access api's that can alter that account. 

- New UserContext scoped service: 
A new UserContext instance will be created for every HTTP Request, lasting the lifespan of the request. the UserContext class responsibility is grabbing user information from the HTTP Request. At the moment, this is just userId, but in the future we can extract things like isMobile, isTablet, and other user specific data.